### PR TITLE
fix: Update Gemini model to gemini-1.5-pro-latest

### DIFF
--- a/tools/resume/create_resume.py
+++ b/tools/resume/create_resume.py
@@ -52,6 +52,6 @@ def create_resume(
     Please generate the full LaTeX code for the resume.
     """
 
-    model = genai.GenerativeModel('gemini-pro')
+    model = genai.GenerativeModel('gemini-1.5-pro-latest')
     response = model.generate_content(prompt)
     return response.text


### PR DESCRIPTION
The previous model, gemini-pro, was causing a 404 error because it is not available in the v1beta API. This change updates the model to gemini-1.5-pro-latest, which is a compatible model and should resolve the issue.